### PR TITLE
Use the default key type

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (comment, path, callback) {
   }
 
   var cmd = "ssh-keygen";
-  var args = ["-t", "dsa", "-C", comment, "-f", path, "-N"]
+  var args = ["-C", comment, "-f", path, "-N"]
   if (process.platform === 'win32') {
     args.push("''")
   } else {


### PR DESCRIPTION
DSA keys are arguably less secure than RSA keys, which is why RSA is the default. Deliberately using DSA keys shouldn't be encouraged.

Using the `ssh-keygen` default should be fine. Letting the user override the key type would be even better though.