### PR TITLE
refactor options (include type), linting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,13 @@
-# Generate and SSH keypair with `ssh-keygen`
+# Generate an SSH keypair with `ssh-keygen`
 
 ## keygen(comment, path, callback(err))
 Generate the keys at the given path. `path` will be the private, and
 `path + '.pub'` will be the public key.
+
+## keygen(comment, options, callback(err))
+Specify an `options` object with fields `path` (used as above) and `type` (which
+determines the type of keys generated - default "rsa", with "ecdsa" being a good
+option if your system supports it).
 
 ## keygen(comment, callback(err, privkey, pubkey))
 Generate the keys to a random path and return them as strings.


### PR DESCRIPTION
It'd be really useful to be able to generate ecdsa keys as well as rsa, so that's what this pull request enables. Most of the other changes are just lint, but I did change the API a bit - specifically now that there's two optional parameters (path and type) I put them in a single optional object that is the third argument to the function.

So, existing calls of the form `keygen(comment, callback)` will still work as before, but calls of the form `keygen(comment, path, callback)` will not. Instead, they should be made in the style `keygen(comment, callback, {path:patharg})`.

I think this approach is cleaner and more extensible, but it is API breaking so is worth consideration. Let me know your thoughts, thanks!
